### PR TITLE
Log Only Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,38 @@
-<#
-.Synopsis
-	Block IP Addresses that connect to a specified port.
+.SYNOPSIS
+    Block IP Addresses that connect to a specified port.
 
 .DESCRIPTION
-	Creates a job that listens on TCP Ports specified and when a connection is established, it adds a local firewall rule to block the host from further connections.  Writes blocked IPs to the event log named HoneyPort.
+    Creates a job that listens on TCP Ports specified and when 
+    a connection is established, it can either simply log or
+    add a local firewall rule to block the host from further
+    connections.
+    Writes blocked/probed IPs to the event log named HoneyPort.
 
 .PARAMETER  Ports
-	List of Ports to listen in for connections.
+    List of Ports to listen in for connections.
 
 .PARAMETER  WhiteList
-	List of IP Addresses that should not be blocked.
+    List of IP Addresses that should not be blocked.
 
 .EXAMPLE
-	Example monitoring on different ports
-	PS C:\> .\honeyport.ps1 -Ports 70,79 -Verbose
+    Example monitoring on different ports
+        PS C:\> .\honeyport.ps1 -Ports 70,79 -Verbose
 
 .EXAMPLE
-	Example monitoring on different ports and add whitelist of hosts
-	PS C:\> .\honeyport.ps1 -Ports 4444,22,21,23 -WhiteList 192.168.10.1,192.168.10.2 -Verbose
+    Example monitoring on different ports and add whitelist of hosts
+        PS C:\> .\honeyport.ps1 -Ports 4444,22,21,23 -WhiteList 192.168.10.1,192.168.10.2 -Verbose
+
+.EXAMPLE
+    Example monitoring on one port and blocking on full TCP connect
+        PS C:\> .\honeyport.ps1 -Ports 21 -Block
 
 .NOTES
-	Authors: John Hoyt, Carlos Perez
-	
-	Stopping HoneyPort; 
-		stop-job -name HoneyPort
-		remove-job -name HoneyPort
-	
-	Listing Events;
-	get-eventlog HoneyPort
-	
-#>
+    Authors: John Hoyt, Carlos Perez
+    Original Script Modified By: Greg Foss
+
+    Stopping HoneyPort; 
+        PS C:\> stop-job -name HoneyPort
+        PS C:\> remove-job -name HoneyPort
+
+    Listing Events;
+        PS C:\> get-eventlog HoneyPort

--- a/honeyport.ps1
+++ b/honeyport.ps1
@@ -1,12 +1,13 @@
 <#
-.Synopsis
+.SYNOPSIS
     Block IP Addresses that connect to a specified port.
 
 .DESCRIPTION
     Creates a job that listens on TCP Ports specified and when 
-    a connection is established, it adds a local firewall 
-    rule to block the host from further connections.
-    Writes blocked IPs to the event log named HoneyPort.
+    a connection is established, it can either simply log or
+    add a local firewall rule to block the host from further
+    connections.
+    Writes blocked/probed IPs to the event log named HoneyPort.
 
 .PARAMETER  Ports
     List of Ports to listen in for connections.
@@ -15,24 +16,27 @@
     List of IP Addresses that should not be blocked.
 
 .EXAMPLE
-   Example monitoring on different ports
-    PS C:\> .\honeyport.ps1 -Ports 70,79 -Verbose
+    Example monitoring on different ports
+        PS C:\> .\honeyport.ps1 -Ports 70,79 -Verbose
 
 .EXAMPLE
-   Example monitoring on different ports and add whitelist of hosts
-   PS C:\> .\honeyport.ps1 -Ports 4444,22,21,23 -WhiteList 192.168.10.1,192.168.10.2 -Verbose
+    Example monitoring on different ports and add whitelist of hosts
+        PS C:\> .\honeyport.ps1 -Ports 4444,22,21,23 -WhiteList 192.168.10.1,192.168.10.2 -Verbose
+
+.EXAMPLE
+    Example monitoring on one port and blocking on full TCP connect
+        PS C:\> .\honeyport.ps1 -Ports 21 -Block
 
 .NOTES
-   Authors: John Hoyt, Carlos Perez
+    Authors: John Hoyt, Carlos Perez
+    Original Script Modified By: Greg Foss
 
-   Stopping HoneyPort; 
-  stop-job -name HoneyPort
-	remove-job -name HoneyPort
+    Stopping HoneyPort; 
+        PS C:\> stop-job -name HoneyPort
+        PS C:\> remove-job -name HoneyPort
 
-   Listing Events;
-	get-eventlog HoneyPort
-
-   
+    Listing Events;
+        PS C:\> get-eventlog HoneyPort
 #>
     
 [CmdletBinding()]
@@ -44,7 +48,9 @@ param(
     [Alias("PortNumber")]
     [int32[]]$Ports,
 
-    [string[]]$WhiteList
+    [string[]]$WhiteList,
+
+    [switch[]]$Block = $false
 ) 
 
 function Check-IsAdmin{
@@ -95,7 +101,7 @@ Check-HoneyPortEvent
 if (Check-IsAdmin) {
     foreach($port in $Ports) {
         $log = "HoneyPort has started listening for connections on port $port"        
-	write-eventlog -logname HoneyPort -source BlueKit -eventID 1001 -entrytype Information -message $log
+	    write-eventlog -logname HoneyPort -source BlueKit -eventID 1001 -entrytype Information -message $log
         Write "Starting job that will listen for connections on port $port"
         Start-Job -ScriptBlock {
             param($port, $whitelist)
@@ -113,6 +119,7 @@ if (Check-IsAdmin) {
 
                 # If the IP is not on the whitelist we block it
     
+            if ($Block -eq $true) {
                 if ($WhiteList -notcontains $IP){
                       write "The following host attempted to connect: $IP"
                       #Add firewall rule to block inbound scanner.
@@ -128,17 +135,24 @@ if (Check-IsAdmin) {
                       $rule.Enabled = $True
                       $firewall.Rules.Add($rule)
                       write "Host has been blocked."
-		      $logIP = "$IP has been blocked on port $port"
-		      write-eventlog -logname HoneyPort -source BlueKit -eventID 1002 -entrytype Information -message $logIP
+		              $logIP = "$IP has been blocked on port $port"
+		              write-eventlog -logname HoneyPort -source BlueKit -eventID 1002 -entrytype Information -message $logIP
                       $client.Close()
                       $listener.stop()	
                       Write "Connection closed"
                 }
-    
+            } Else {
+                $logIP = "$IP has probed the HoneyPort on port $port"
+                write-eventlog -logname HoneyPort -source BlueKit -eventID 1002 -entrytype Information -message $logIP
+                $client.Close()
+                $listener.stop()	
+                Write "Connection closed"
             }
-        } -ArgumentList $port,$WhiteList -Name "HoneyPort" -ErrorAction Stop
+
+            }
+        } -ArgumentList $port,$WhiteList,$Block -Name "HoneyPort" -ErrorAction Stop
     }
 }
 else {
-    Write-Error "Script needs to be ran with higher privileges"
+    Write-Error "Script needs to be run with higher privileges"
 }

--- a/honeyport.ps1
+++ b/honeyport.ps1
@@ -152,7 +152,23 @@ if (Check-IsAdmin) {
             }
         } -ArgumentList $port,$WhiteList,$Block -Name "HoneyPort" -ErrorAction Stop
     }
-}
-else {
+
+    # Terminate Honeyport and Log Job Completion
+    Write-Host "To terminate the HoneyPort, create the file $PSScriptRoot\stop.txt"
+
+    # Wait for terminate 'command'
+
+    while ($true) {
+        start-sleep 60
+        if (Test-Path "$PSScriptRoot\stop.txt") {
+            stop-job HoneyPort
+            remove-job HoneyPort
+            $log = "HoneyPort has stopped listening for connections on all ports"
+            Write-EventLog -LogName HoneyPort -source BlueKit -eventID 1003 -entrytype Information -message $log
+            break
+        }
+    }
+    
+} else {
     Write-Error "Script needs to be run with higher privileges"
 }


### PR DESCRIPTION
Set blocking as an option that requires the -Block switch to be passed at run-time. This is something that many of my clients have requested when running HoneyPorts on Windows hosts.
